### PR TITLE
feat: history 관련 API 구현(편집된 문서 목록)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('users/', include('users.urls')),
     path('users/', include('allauth.urls')),
+    path('history/', include('documents.urls')),
 ]

--- a/documents/serializers.py
+++ b/documents/serializers.py
@@ -1,0 +1,19 @@
+# documents/serializers.py
+from rest_framework import serializers
+from .models import HistoryDoc, Generation
+from users.models import User
+
+class HistoryDocSerializer(serializers.ModelSerializer):
+    generation = serializers.SerializerMethodField()
+    author = serializers.SerializerMethodField()
+
+    class Meta:
+        model = HistoryDoc
+        fields = ['id', 'title', 'generation', 'updated_at', 'created_at', 'author', 'content']
+
+    def get_generation(self, obj):
+        generations = Generation.objects.filter(title=obj).values_list('generation', flat=True)
+        return list(generations)
+
+    def get_author(self, obj):
+        return obj.author.name

--- a/documents/urls.py
+++ b/documents/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from .views import *
 
 urlpatterns = [
-    
+    path('recent/', RecentEditedDocumentsAPI.as_view(), name='최근 편집된 전체 문서 목록'),
+    path('<str:title>/', DocumentEditHistoryAPI.as_view(), name='특정 문서의 전체 편집 목록'),    
 ]

--- a/documents/views.py
+++ b/documents/views.py
@@ -1,3 +1,34 @@
 from django.shortcuts import render
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from .models import HistoryDoc
+from .serializers import HistoryDocSerializer
 
-# Create your views here.
+# 최근 편집된 전체 문서 목록
+class RecentEditedDocumentsAPI(APIView):
+    def get(self, request):
+        try:
+            recent_docs = HistoryDoc.objects.order_by('-updated_at')[:5]
+            serializer = HistoryDocSerializer(recent_docs, many=True)
+            return Response({
+                "status": "200",
+                "message": "success",
+                "data": serializer.data
+            })
+        except Exception as e:
+            return Response({"message": "Bad Request"}, status=status.HTTP_400_BAD_REQUEST)
+
+# 특정 문서의 전체 편집 목록
+class DocumentEditHistoryAPI(APIView):
+    def get(self, request, title):
+        if not HistoryDoc.objects.filter(title=title).exists():
+            return Response({"message": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
+
+        docs = HistoryDoc.objects.filter(title=title).order_by('-updated_at')
+        serializer = HistoryDocSerializer(docs, many=True)
+        return Response({
+            "status": "200",
+            "message": "success",
+            "data": serializer.data
+        })


### PR DESCRIPTION
## 📌 PR 내용
***
- documents 중 history 관련 API 구현(편집된 문서 목록)

## 📝 코드 요약
***
- 'documents/serializers.py' : documents 관련 DRF 세팅
- 'config/urls.py' : history 관련 urls 업데이트
- 'documents/urls.py' : history 관련 urls 업데이트
- 'documents/views.py' : history 관련 views 업데이트

## 💌 해결 이슈
***
- Resolved : #9 

## 📸 스크린샷 (선택)
***