### PR TITLE
feat: 임의 문서 조회, 기수별 필터링, 검색

### DIFF
--- a/documents/urls.py
+++ b/documents/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('recent/', RecentEditedDocumentsAPI.as_view(), name='최근 편집된 전체 문서 목록'),
     path('<str:title>/', DocumentEditHistoryAPI.as_view(), name='특정 문서의 전체 편집 목록'),
     path('random', RandomDocAPI.as_view(), name = '임의 문서 가져오기'),    
-    path('<int:generation>', GenerationFilteredDocAPI.as_view(), name = '기수로 분류된 문서 전체 조회')
+    path('<int:generation>', GenerationFilteredDocAPI.as_view(), name = '기수로 분류된 문서 전체 조회'),
+    path('search/<str:keyword>', SearchHistoryDocAPI.as_view(), name="문서 검색")
 ]

--- a/documents/urls.py
+++ b/documents/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import HistoryDocCreateAPI, DocDetailAPI, RecentEditedDocumentsAPI, DocumentEditHistoryAPI, RandomDocAPI
+from .views import *
 
 urlpatterns = [
     path('', HistoryDocCreateAPI.as_view(), name = '문서 작성'),
@@ -7,4 +7,5 @@ urlpatterns = [
     path('recent/', RecentEditedDocumentsAPI.as_view(), name='최근 편집된 전체 문서 목록'),
     path('<str:title>/', DocumentEditHistoryAPI.as_view(), name='특정 문서의 전체 편집 목록'),
     path('random', RandomDocAPI.as_view(), name = '임의 문서 가져오기'),    
+    path('<int:generation>', GenerationFilteredDocAPI.as_view(), name = '기수로 분류된 문서 전체 조회')
 ]

--- a/documents/urls.py
+++ b/documents/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
-from .views import *
+from .views import HistoryDocCreateAPI, DocDetailAPI, RecentEditedDocumentsAPI, DocumentEditHistoryAPI, RandomDocAPI
 
 urlpatterns = [
     path('', HistoryDocCreateAPI.as_view(), name = '문서 작성'),
     path('recent/<str:title>/', DocDetailAPI.as_view(), name = '특정 문서 중 가장 최근 편집된 글 가져오기'),
     path('recent/', RecentEditedDocumentsAPI.as_view(), name='최근 편집된 전체 문서 목록'),
     path('<str:title>/', DocumentEditHistoryAPI.as_view(), name='특정 문서의 전체 편집 목록'),
-    path('random/', RandomDocAPI.as_view(), name = '임의 문서 가져오기'),    
+    path('random', RandomDocAPI.as_view(), name = '임의 문서 가져오기'),    
 ]

--- a/documents/views.py
+++ b/documents/views.py
@@ -47,7 +47,7 @@ class DocumentEditHistoryAPI(APIView):
             "data": serializer.data
         })
 
-# 특정 문서 중 가장 최신의 문서 가져오기
+# 특정 문서 중 가장 최신의 문서 가져오기(CurrDoc 활용)
 class DocDetailAPI(APIView):
      def get(self, request, title, format=None):
         try:
@@ -61,16 +61,14 @@ class DocDetailAPI(APIView):
                 status=status.HTTP_404_NOT_FOUND)
          
 
-# 임의 문서 가져오기(CurrDoc 활용)
+# 임의 문서 가져오기
 class RandomDocAPI(APIView):
     def get(self, request, format=None):
-        docs = HistoryDoc.objects.all()
-        if docs.exists():
-            # 랜덤한 문서뽑기
-            random_doc = choice(docs)
-            # 같은 title에 대해 최신 문서 가져오기
-            latest_doc = HistoryDoc.objects.filter(title=random_doc.title).order_by("-created_at").first()
-            serializer = HistoryDocSerializer(data = latest_doc.data)
+        curr_docs = CurrDoc.objects.all()
+        if curr_docs.exists():
+            # 랜덤한 CurrDoc 선택
+            random_doc = choice(list(curr_docs))
+            serializer = HistoryDocSerializer(random_doc.history_doc)
             return Response(serializer.data) 
         else:
             return Response({"error": "No documents found"}, status=status.HTTP_404_NOT_FOUND)

--- a/documents/views.py
+++ b/documents/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.db.models import Max
+from django.db.models import Q
 from random import choice
 from rest_framework import status
 from rest_framework.views import APIView
@@ -99,3 +100,17 @@ class GenerationFilteredDocAPI(APIView):
             return Response({
                 "message": "No documents found"}, 
                 status=status.HTTP_404_NOT_FOUND)
+
+class SearchHistoryDocAPI(APIView):
+    def get(self, request,keyword):
+        queryset = HistoryDoc.objects.filter(Q(title__icontains = keyword) | Q(content__icontains = keyword), curr_docs__isnull=False)\
+        .order_by('-created_at')[:3]
+
+        if queryset.exists():
+            serializer = HistoryDocSerializer(queryset, many=True)
+            return Response(serializer.data)
+        else:
+            return Response({
+                "message" : "No documents found"},
+                status=status.HTTP_404_NOT_FOUND
+            )


### PR DESCRIPTION
## 📌 PR 내용
***
-get 'docs/random' : 임의의 CurrDoc 객체가 참조하는 HistoryDoc 객체 반환
-get 'docs/'<int:generation>'' : 기수별 CurrDoc이 참조하는 HistoryDoc 목록 조회
-get 'docs/search/<str:keyword>' : 문서 검색


## 📝 코드 요약
***
`documents/views.py` 
- RandomDocAPI : 랜덤한 CurrDoc 객체 선택 후, 그 객체가 참조하고 있는 HistoryDoc 객체 반환
- GenerationFilteredDocAPI : path 파라미터로 받은 값(기수)에 대해 Generation 모델이 참조하는 HistoryDoc에서  CurrDoc이 참조하는 객체만 선택하고, 각 title에 대해 가장 최신의 HistoryDoc 객체를 반환
- SearchHistoryDocAPI : path 파라미터로 받은 키워드에 대해 CurrDoc이 참조하는 HistoryDoc의 객체의 title 검색, 정확히 일치하는 문서가 있으면 해당 문서 반환, 일치 문서 없으면 content에서 검색 후 포함되어 있는 객체를 3개 이하로 반환

## 비고
`documents/urls.py`
이상하게 슬래쉬(/)를 마지막에 붙이면 url mapping이 안되더라구요..?

## 💌 해결 이슈
***
- Resolved : #5 

## 📸 스크린샷 (선택)
***
<img width="356" alt="임의 문서 조회" src="https://github.com/cau-likelion-org/kiwi-server/assets/127576762/5949bb9e-fbed-4e7d-9a49-d73b6a68dcd0">
<img width="442" alt="기수별 필터링" src="https://github.com/cau-likelion-org/kiwi-server/assets/127576762/87ac28ae-8fc0-4b5a-beb2-f63b89e99bfa">
