### PR TITLE
feat: docs backlink

### DIFF
--- a/documents/serializers.py
+++ b/documents/serializers.py
@@ -24,6 +24,7 @@ class HistoryDocSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         generations_data = validated_data.pop('generations')
         author = self.context['request'].user
+        title = validated_data.get('title')
         
         history_data = {**validated_data, 'author': author}
         history_doc = HistoryDoc.objects.create(**history_data)
@@ -31,13 +32,13 @@ class HistoryDocSerializer(serializers.ModelSerializer):
         for generation_data in generations_data:
             Generation.objects.create(title=history_doc, **generation_data)
         
-    
         curr_doc = CurrDoc.objects.filter(history_doc__title=history_doc.title).first()
-
+       
         if curr_doc is None:
-            curr_doc = CurrDoc.objects.create(history_doc=history_doc)
+            curr_doc = CurrDoc.objects.create(history_doc=history_doc, title= title)
         else:  
             curr_doc.history_doc = history_doc
+            curr_doc.title = title
             curr_doc.save()
 
         return history_doc

--- a/documents/urls.py
+++ b/documents/urls.py
@@ -7,7 +7,8 @@ urlpatterns = [
     path('random', RandomDocAPI.as_view(), name = '임의 문서 가져오기'),    
     path('<int:generation>', GenerationFilteredDocAPI.as_view(), name = '기수로 분류된 문서 전체 조회'),
     path('search/<str:keyword>', SearchHistoryDocAPI.as_view(), name="문서 검색"),
-  
+    path('backlink/<str:title>/', BackLinkAPI.as_view(), name='역링크 조회'),
+
     path('recent/', RecentEditedDocumentsAPI.as_view(), name='최근 편집된 전체 문서 목록'),
     path('<str:title>/', DocumentEditHistoryAPI.as_view(), name='특정 문서의 전체 편집 목록'),
     path('<str:title>/detail/', DocumentEditComparisonAPI.as_view(), name='특정 문서의 편집 변경 사항'), 


### PR DESCRIPTION
## 📌 PR 내용
***
- currDoc 중 나의 최신문서조회 api 엔드포인트를 포함하고 있는 historyDoc을 참조하고 있는 currDoc의 title을 반환합니다.

## 📝 코드 요약
***
`BackLinkAPI`
path parameter로 넘어온 문서 title에 대해 title의 currDoc을 제외한 currDoc 객체가 참조하는 HistoryDoc의 content에 최신 버전의 문서를 조회하는  'http://127.0.0.1:8000/docs/recent/<str:title>' 을 포함하고 있으면 배열에 넣습니다.

## 💌 해결 이슈
***
- Resolved : #18 

## 📸 스크린샷 (선택)
***
<img width="377" alt="역링크" src="https://github.com/cau-likelion-org/kiwi-server/assets/127576762/9009b82a-42f4-4c44-93de-f890df4d5b6b">
