### PR TITLE
fix: docs, history urlpatterns 분리

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -16,11 +16,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from documents.urls import docs_urlpatterns, history_urlpatterns
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('users/', include('users.urls')),
     path('users/', include('allauth.urls')),
-    path('docs/', include('documents.urls')),
-    path('history/', include('documents.urls')),
+    path('docs/', include(docs_urlpatterns)),
+    path('history/', include(history_urlpatterns)),
 ]

--- a/documents/urls.py
+++ b/documents/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from .views import *
 
-urlpatterns = [
+docs_urlpatterns = [
     path('', HistoryDocCreateAPI.as_view(), name = '문서 작성'),
     path('recent/<str:title>/', DocDetailAPI.as_view(), name = '특정 문서 중 가장 최근 편집된 글 가져오기'),
     path('random/', RandomDocAPI.as_view(), name = '임의 문서 가져오기'),    
@@ -9,7 +9,9 @@ urlpatterns = [
     path('search/<str:keyword>/', SearchHistoryDocAPI.as_view(), name="문서 검색"),
     path('backlink/<str:title>/', BackLinkAPI.as_view(), name='역링크 조회'),
     path('image/',ImageUploadView.as_view(), name='이미지 업로드' ),
+]
 
+history_urlpatterns = [
     path('recent/', RecentEditedDocumentsAPI.as_view(), name='최근 편집된 전체 문서 목록'),
     path('<str:title>/', DocumentEditHistoryAPI.as_view(), name='특정 문서의 전체 편집 목록'),
     path('<str:title>/detail/', DocumentEditComparisonAPI.as_view(), name='특정 문서의 편집 변경 사항'), 


### PR DESCRIPTION
## 📌 PR 내용
***
- documents 내 docs, history로 구분했던 API의 URL 패턴이 비슷해서 발생하는 충돌을 해결하기 위해 docs, history API의 urlpatterns 분리

## 📝 코드 요약
***
- 'config/urls.py' : urls 매칭 수정
- 'documents/urls.py' : urlpatterns 분리

## 💌 해결 이슈
***
- Resolved : #34

## 📸 스크린샷 (선택)
***