### PR TITLE
fix: 최근 편집된 전체 문서 목록의 동일 문서 중복 제거

### DIFF
--- a/documents/views.py
+++ b/documents/views.py
@@ -44,10 +44,10 @@ class RecentEditedDocumentsAPI(APIView):
             "data": data
         })
 
-# 특정 문서의 전체 편집 목록
+#  특정 문서의 전체 편집 목록
 class DocumentEditHistoryAPI(APIView):
     def get(self, request, title):
-        docs = HistoryDoc.objects.filter(title=title).order_by('-updated_at').first()
+        docs = HistoryDoc.objects.filter(title=title).order_by('-updated_at')
 
         if not docs.exists():
             return Response({"message": "Not Found"}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## 📌 PR 내용
***
- 최근 편집된 전체 문서 목록 API에서 특정 게시물의 수정 목록이 2개 이상 포함될 경우 가장 최근 편집 목록 하나만 리턴 되도록 수정

## 📝 코드 요약
***
- 'documents/views.py' : 최근 편집된 전체 문서 목록 API 수정

## 💌 해결 이슈
***
- Resolved : #39 

## 📸 스크린샷 (선택)
***