### PR TITLE
fix: 최근 편집된 전체 문서 목록의 동일 문서 중복 제거

### DIFF
--- a/documents/views.py
+++ b/documents/views.py
@@ -29,7 +29,7 @@ class HistoryDocCreateAPI(APIView):
 # 최근 편집된 전체 문서 목록
 class RecentEditedDocumentsAPI(APIView):
     def get(self, request):
-        latest_updates = HistoryDoc.objects.values('title').annotate(latest_update=Max('updated_at'))
+        latest_updates = HistoryDoc.objects.values('title').annotate(latest_update=Max('updated_at')).order_by('-latest_update')
 
         data = []
         for update in latest_updates[:5]:


### PR DESCRIPTION
## 📌 PR 내용
***
- 최근 편집된 전체 문서 목록 API에서 특정 게시물의 수정 목록이 2개 이상 포함될 경우 가장 최근 편집 목록 하나만 리턴 되도록 수정(시간 순서 정렬)

## 📝 코드 요약
***
- 'documents/views.py' : 최근 편집된 전체 문서 목록 API 수정

## 💌 해결 이슈
***
- Resolved : #39

## 📸 스크린샷 (선택)
***